### PR TITLE
Support multiple steam libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ To install these, open a command prompt and run these two commands:
 `pip install requests`
 
 `pip install bs4`
+
+# Configuration
+
+Edit the config.json in the wox plugin settings folder and put your steam library folder(s) inside.
+
+Examples:
+
+Single Steam Library:
+```
+{
+    "steamapps_dir": "C:\\Games\\steamapps"
+}
+```
+
+Multiple Steam Libraries:
+```
+{
+    "steamapps_dir": ["C:\\Games\\steamapps", "D:\\Games\\Steam\\steamapps"]
+}
+```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ A steam game launcher plugin for Wox
 When you first time using this function, type `/st` and wait a second for setting up.
 
 ![preview](https://github.com/mycraftmw/Wox.Plugin.SteamGames/blob/master/preview.png)
+
+# Requirements
+This plugin requries the python module `requests` and `bs4`.
+To install these, open a command prompt and run these two commands:
+`pip install requests`
+`pip install bs4`

--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ When you first time using this function, type `/st` and wait a second for settin
 # Requirements
 This plugin requries the python module `requests` and `bs4`.
 To install these, open a command prompt and run these two commands:
+
 `pip install requests`
+
 `pip install bs4`

--- a/SteamGames/main.py
+++ b/SteamGames/main.py
@@ -23,42 +23,12 @@ class Steamlauncher(Wox):
     if not dirConfig["steamapps_dir"]:
         steamappsDir = None
     else:
-        if os.path.isdir(dirConfig["steamapps_dir"]):
-            steamappsDir = dirConfig["steamapps_dir"]
-            for file_entry in os.scandir(steamappsDir):
-                if "appmanifest" in file_entry.name:
-                    gameId = file_entry.name.replace("appmanifest_", "").replace(
-                        ".acf", ""
-                    )
-                    if gameId == "228980":
-                        continue
-                    with open(file_entry.path) as f:
-                        for line in f:
-                            if line.find("name") > 0:
-                                gameTitle = (
-                                    line.replace('"', "").replace("name", "").strip()
-                                )
-                                break
-                    if os.path.isfile("./icon/" + gameId + ".jpg"):
-                        gameIcon = "./icon/" + gameId + ".jpg"
-                    else:
-                        try:
-                            url = "https://steamdb.info/app/{}/".format(gameId)
-                            headers = {
-                                "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:47.0) Gecko/20100101 Firefox/47.0"
-                            }
-                            r = requests.get(url, headers=headers)
-                            soup = BeautifulSoup(r.text, "html.parser")
-                            data = soup.find("img", attrs={"class": "app-icon avatar"})
-                            img = data.attrs["src"]
-                            urllib.request.urlretrieve(img, "./icon/" + gameId + ".jpg")
-                            gameIcon = "./icon/" + gameId + ".jpg"
-                            gameIcon = "./icon/missing.png"
-                        except Exception as e:
-                            gameIcon = "./icon/missing.png"
-                    gameList.append(
-                        {"gameId": gameId, "gameTitle": gameTitle, "gameIcon": gameIcon}
-                    )
+        if type(dirConfig["steamapps_dir"]) is list:
+            for directory in dirConfig["steamapps_dir"]:
+               if os.path.isdir(directory):
+                    collectGames(directory)
+        elif os.path.isdir(dirConfig["steamapps_dir"]):
+            collectGames(dirConfig["steamapps_dir"])
         else:
             steamappsDir = False
 
@@ -89,6 +59,43 @@ class Steamlauncher(Wox):
 
     def launchGame(self, gameId):
         webbrowser.open("steam://rungameid/{}".format(gameId))
+
+def collectGames(directory):
+    steamappsDir = directory
+    for file_entry in os.scandir(steamappsDir):
+        if "appmanifest" in file_entry.name:
+            gameId = file_entry.name.replace("appmanifest_", "").replace(
+                ".acf", ""
+            )
+            if gameId == "228980":
+                continue
+            with open(file_entry.path) as f:
+                for line in f:
+                    if line.find("name") > 0:
+                        gameTitle = (
+                            line.replace('"', "").replace("name", "").strip()
+                        )
+                        break
+            if os.path.isfile("./icon/" + gameId + ".jpg"):
+                gameIcon = "./icon/" + gameId + ".jpg"
+            else:
+                try:
+                    url = "https://steamdb.info/app/{}/".format(gameId)
+                    headers = {
+                        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:47.0) Gecko/20100101 Firefox/47.0"
+                    }
+                    r = requests.get(url, headers=headers)
+                    soup = BeautifulSoup(r.text, "html.parser")
+                    data = soup.find("img", attrs={"class": "app-icon avatar"})
+                    img = data.attrs["src"]
+                    urllib.request.urlretrieve(img, "./icon/" + gameId + ".jpg")
+                    gameIcon = "./icon/" + gameId + ".jpg"
+                    gameIcon = "./icon/missing.png"
+                except Exception as e:
+                    gameIcon = "./icon/missing.png"
+            gameList.append(
+                {"gameId": gameId, "gameTitle": gameTitle, "gameIcon": gameIcon}
+            )
 
 
 if __name__ == "__main__":

--- a/SteamGames/main.py
+++ b/SteamGames/main.py
@@ -20,15 +20,52 @@ class Steamlauncher(Wox):
     dirConfig = json.load(f)
     f.close()
 
+    def collectGames(directory, intoGameList):
+        steamappsDir = directory
+        for file_entry in os.scandir(steamappsDir):
+            if "appmanifest" in file_entry.name:
+                gameId = file_entry.name.replace("appmanifest_", "").replace(
+                    ".acf", ""
+                )
+                if gameId == "228980":
+                    continue
+                with open(file_entry.path) as f:
+                    for line in f:
+                        if line.find("name") > 0:
+                            gameTitle = (
+                                line.replace('"', "").replace("name", "").strip()
+                            )
+                            break
+                if os.path.isfile("./icon/" + gameId + ".jpg"):
+                    gameIcon = "./icon/" + gameId + ".jpg"
+                else:
+                    try:
+                        url = "https://steamdb.info/app/{}/".format(gameId)
+                        headers = {
+                            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:47.0) Gecko/20100101 Firefox/47.0"
+                        }
+                        r = requests.get(url, headers=headers)
+                        soup = BeautifulSoup(r.text, "html.parser")
+                        data = soup.find("img", attrs={"class": "app-icon avatar"})
+                        img = data.attrs["src"]
+                        urllib.request.urlretrieve(img, "./icon/" + gameId + ".jpg")
+                        gameIcon = "./icon/" + gameId + ".jpg"
+                        gameIcon = "./icon/missing.png"
+                    except Exception as e:
+                        gameIcon = "./icon/missing.png"
+                intoGameList.append(
+                    {"gameId": gameId, "gameTitle": gameTitle, "gameIcon": gameIcon}
+                )
+
     if not dirConfig["steamapps_dir"]:
         steamappsDir = None
     else:
         if type(dirConfig["steamapps_dir"]) is list:
             for directory in dirConfig["steamapps_dir"]:
                if os.path.isdir(directory):
-                    collectGames(directory)
+                    collectGames(directory, gameList)
         elif os.path.isdir(dirConfig["steamapps_dir"]):
-            collectGames(dirConfig["steamapps_dir"])
+            collectGames(dirConfig["steamapps_dir"], gameList)
         else:
             steamappsDir = False
 
@@ -60,42 +97,6 @@ class Steamlauncher(Wox):
     def launchGame(self, gameId):
         webbrowser.open("steam://rungameid/{}".format(gameId))
 
-def collectGames(directory):
-    steamappsDir = directory
-    for file_entry in os.scandir(steamappsDir):
-        if "appmanifest" in file_entry.name:
-            gameId = file_entry.name.replace("appmanifest_", "").replace(
-                ".acf", ""
-            )
-            if gameId == "228980":
-                continue
-            with open(file_entry.path) as f:
-                for line in f:
-                    if line.find("name") > 0:
-                        gameTitle = (
-                            line.replace('"', "").replace("name", "").strip()
-                        )
-                        break
-            if os.path.isfile("./icon/" + gameId + ".jpg"):
-                gameIcon = "./icon/" + gameId + ".jpg"
-            else:
-                try:
-                    url = "https://steamdb.info/app/{}/".format(gameId)
-                    headers = {
-                        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:47.0) Gecko/20100101 Firefox/47.0"
-                    }
-                    r = requests.get(url, headers=headers)
-                    soup = BeautifulSoup(r.text, "html.parser")
-                    data = soup.find("img", attrs={"class": "app-icon avatar"})
-                    img = data.attrs["src"]
-                    urllib.request.urlretrieve(img, "./icon/" + gameId + ".jpg")
-                    gameIcon = "./icon/" + gameId + ".jpg"
-                    gameIcon = "./icon/missing.png"
-                except Exception as e:
-                    gameIcon = "./icon/missing.png"
-            gameList.append(
-                {"gameId": gameId, "gameTitle": gameTitle, "gameIcon": gameIcon}
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds support for multiple steam library folders (a setup that many users have).

It does this by extracting the game list creation logic into a function that takes a folder as an argument, and if it detects an array in `config.json` it will pass each folder into the function. If a single string is detected, it works like before and only iterates that single folder.

I also updated the readme to tell users that they need to install `requests` and `bs4` as python modules, since out of the box I was getting errors that these were not installed.

Hope this helps!

Owen